### PR TITLE
Building the transient debug trees now happen in-place during parse-time

### DIFF
--- a/parsley-debug/shared/src/main/scala/parsley/debugger/DebugTree.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/DebugTree.scala
@@ -65,7 +65,7 @@ trait DebugTree {
 
   // Print a parse attempt in a human-readable way.
   private def printParseAttempt(attempt: ParseAttempt): String =
-    s"(\"${attempt.rawInput}\" [${attempt.fromPos} -> ${attempt.toPos}], ${if (attempt.success) "Success" else "Failure"})"
+    s"(\"${attempt.rawInput}\" [${attempt.fromPos} -> ${attempt.toPos}], ${if (attempt.success) s"Success - [ ${attempt.result.get} ]" else "Failure"})"
 
   // Print all the children, remembering to add a blank indent for the last child.
   @tailrec private def printChildren

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/ParseAttempt.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/ParseAttempt.scala
@@ -11,6 +11,9 @@ package parsley.debugger
   * @param fromPos    [[fromOffset]] represented as a (line, column) pair.
   * @param toPos      [[toOffset]] represented as a (line, column pair).
   * @param success    Was this parse attempt successful?
+  * @param result     If this parse attempt was successful, what did it return?
+  *                   It is guaranteed that [[result.isDefined]] is true if and only if the attempt
+  *                   is successful.
   */
 case class ParseAttempt
   ( rawInput: String
@@ -19,7 +22,12 @@ case class ParseAttempt
   , fromPos: (Int, Int)
   , toPos: (Int, Int)
   , success: Boolean
+  // It is guaranteed by the debugger that success <=> result.isDefined.
+  , result: Option[Any]
   ) extends AnyRef {
+  // Make sure this class has not been used improperly.
+  assert(success == result.isDefined)
+
   // We want most of the benefits of a case class, but equals and hashCode are not what we want.
   // This allows disambiguation of attempts in a list, as they are all supposed to be "unique".
   override def equals(obj: Any): Boolean = super.equals(obj)

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugContext.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugContext.scala
@@ -3,63 +3,86 @@
  */
 package parsley.debugger.internal
 
-import parsley.debugger.ParseAttempt
-
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
+import parsley.debugger.ParseAttempt
 import parsley.internal.deepembedding.frontend.LazyParsley
+
+import scala.collection.mutable.ListBuffer
 
 // Class used to hold details about a parser being debugged.
 // This is normally held as a value inside an implicit variable.
 private [parsley] class DebugContext {
   // Tracks how many parsers deep we are.
-  private var currentParserStack: List[LazyParsley[_]] = Nil
+  //  private var currentParserStack: List[LazyParsley[_]] = Nil
+  //
+  //  private val nodes: mutable.Map[List[LazyParsley[_]], TransientDebugTree] = new mutable.LinkedHashMap()
 
-  private val nodes: mutable.Map[List[LazyParsley[_]], TransientDebugTree] = new mutable.LinkedHashMap()
+  private var builderStack: ListBuffer[DebugTreeBuilder] =
+    ListBuffer(DebugTreeBuilder(TransientDebugTree("ROOT", "ROOT", "NIL")))
 
-  // Get an immutable map of nodes.
-  def getNodes: Map[List[LazyParsley[_]], TransientDebugTree] =
-    nodes.foldRight[ListMap[List[LazyParsley[_]], TransientDebugTree]](ListMap())((p, acc) => acc + p)
+  //  // Get an immutable map of nodes.
+  //  def getNodes: Map[List[LazyParsley[_]], TransientDebugTree] =
+  //    nodes.foldRight[ListMap[List[LazyParsley[_]], TransientDebugTree]](ListMap())((p, acc) => acc + p)
+
+  // Get the final DebugTreeBuilder from this context.
+  def getFinalBuilder: DebugTreeBuilder =
+    builderStack.head.bChildren.collectFirst { case (_, x) => x }.get
 
   // Add an attempt of parsing at the current stack point.
-  def addParseAttempt(fullInput: String, attempt: ParseAttempt): Unit =
-    currentParserStack match {
-      case Nil    =>
-        // This shouldn't ever be reached unless something horribly wrong happened to the
-        // instruction generation or execution of the parser.
-        println("WARNING: parser stack underflow when adding attempt.")
-      case p :: _ =>
-        // This tree will be populated as the parser is run.
-        // The name of the parser will be the class name of the parser, translated into
-        // something more human-friendly.
-        val tree = nodes.getOrElseUpdate(currentParserStack, {
-          val newTree = TransientDebugTree(fullInput = fullInput)
-          newTree.name = Rename(p)
-          newTree.internal = Rename.partial(p)
-          newTree
-        })
-
-        tree.parses.append(attempt)
-    }
+  def addParseAttempt(attempt: ParseAttempt): Unit =
+    builderStack.head.node.parses.append(attempt)
+  //    currentParserStack match {
+  //      case Nil    =>
+  //        // This shouldn't ever be reached unless something horribly wrong happened to the
+  //        // instruction generation or execution of the parser.
+  //        println("WARNING: parser stack underflow when adding attempt.")
+  //      case p :: _ =>
+  //        // This tree will be populated as the parser is run.
+  //        // The name of the parser will be the class name of the parser, translated into
+  //        // something more human-friendly.
+  //        val tree = nodes.getOrElseUpdate(currentParserStack, {
+  //          val newTree = TransientDebugTree(fullInput = fullInput)
+  //          newTree.name = Rename(p)
+  //          newTree.internal = Rename.partial(p)
+  //          newTree
+  //        })
+  //
+  //        tree.parses.append(attempt)
+  //    }
 
   // Reset this context back to zero.
   def reset(): Unit = {
-    currentParserStack = Nil
-    nodes.clear()
+    builderStack = ListBuffer(DebugTreeBuilder(TransientDebugTree("ROOT", "ROOT", "NIL")))
+  }
+
+  private def mapHead[A](f: A => A, xs: List[A]): List[A] = xs match {
+    case Nil => Nil
+    case y :: ys => f(y) :: ys
   }
 
   // Push a new parser onto the parser callstack.
-  def push(parser: LazyParsley[_]): Unit =
-    currentParserStack = parser :: currentParserStack
+  def push(fullInput: String, parser: LazyParsley[_]): Unit =
+    if (builderStack.head.bChildren.contains(parser)) {
+      builderStack.prepend(builderStack.head.bChildren(parser))
+    } else {
+      val newTree = TransientDebugTree(fullInput = fullInput)
+      newTree.name = Rename(parser)
+      newTree.internal = Rename.partial(parser)
+
+      val dtb = DebugTreeBuilder(newTree)
+
+      builderStack.head.bChildren(parser) = dtb
+      builderStack.prepend(dtb)
+    }
 
   // Pop a parser off the parser callstack.
   def pop(): Unit =
-    currentParserStack = currentParserStack match {
-      case Nil       =>
-        // Shouldn't happen, but just in case.
-        println("WARNING: parser stack underflow on pop.")
-        Nil
-      case _ :: rest =>
-        rest
+    if (builderStack.isEmpty) {
+      // Shouldn't happen, but just in case.
+      println("WARNING: parser stack underflow on pop.")
+    } else {
+      // Remove first item.
+      builderStack.remove(0)
     }
 }

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
@@ -1,6 +1,7 @@
 package parsley.debugger.internal
 
 import scala.collection.immutable.ListMap
+import scala.collection.mutable
 
 import parsley.internal.deepembedding.frontend.LazyParsley
 
@@ -8,19 +9,9 @@ import parsley.internal.deepembedding.frontend.LazyParsley
 // Not meant to be public.
 private [parsley] case class DebugTreeBuilder(
   node: TransientDebugTree,
-  bChildren: Map[LazyParsley[Any], DebugTreeBuilder] = ListMap.empty,
+  bChildren: mutable.Map[LazyParsley[Any], DebugTreeBuilder] = mutable.LinkedHashMap()
 ) {
   private var uid = 0
-
-  def addNode(path: List[LazyParsley[Any]], node: TransientDebugTree): DebugTreeBuilder =
-    path match {
-      case Nil      => DebugTreeBuilder(node, ListMap.empty)
-      case p :: ps  =>
-        // Pre: The path to this node must fully exist.
-        // Tip: Add the shortest paths first!
-        val child = this.bChildren.getOrElse(p, DebugTreeBuilder(node))
-        DebugTreeBuilder(this.node, this.bChildren + ((p, child.addNode(ps, node))))
-    }
 
   def reconstruct: TransientDebugTree = {
     node.children

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
@@ -1,6 +1,5 @@
 package parsley.debugger.internal
 
-import scala.collection.immutable.ListMap
 import scala.collection.mutable
 
 import parsley.internal.deepembedding.frontend.LazyParsley

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
@@ -25,25 +25,3 @@ private [parsley] case class DebugTreeBuilder(
     node
   }
 }
-
-private [debugger] sealed abstract class SometimesEquatable[A](val item: A) {
-  override def toString: String = s"$item [?=]"
-}
-
-private [debugger] final class Equatable[A](item: A)
-  extends SometimesEquatable[A](item) {
-  override def equals(obj: Any): Boolean = obj match {
-    case eq: Equatable[A] => eq.item.equals(item)
-    case _                => false
-  }
-
-  override def hashCode(): Int = item.hashCode()
-}
-
-private [debugger] final class Referential[A](item: A)
-  extends SometimesEquatable[A](item)
-
-private [debugger] object SometimesEquatable {
-  def equatable[A](item: A): SometimesEquatable[A] = new Equatable[A](item)
-  def referential[A](item: A): SometimesEquatable[A] = new Referential[A](item)
-}

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
@@ -8,14 +8,14 @@ import parsley.internal.deepembedding.frontend.LazyParsley
 // Not meant to be public.
 private [parsley] case class DebugTreeBuilder(
   node: TransientDebugTree,
-  bChildren: mutable.Map[LazyParsley[Any], DebugTreeBuilder] = mutable.LinkedHashMap()
+  bChildren: mutable.Map[SometimesEquatable[LazyParsley[Any]], DebugTreeBuilder] = mutable.LinkedHashMap()
 ) {
   private var uid = 0
 
   def reconstruct: TransientDebugTree = {
     node.children
       .addAll(
-        bChildren.map { case (lp, cs) => (Rename(lp) + s"-#${{
+        bChildren.map { case (lp, cs) => (Rename(lp.item) + s"-#${{
           val uuid = uid
           uid = uid + 1
           uuid
@@ -24,4 +24,26 @@ private [parsley] case class DebugTreeBuilder(
 
     node
   }
+}
+
+private [debugger] sealed abstract class SometimesEquatable[A](val item: A) {
+  override def toString: String = s"$item [?=]"
+}
+
+private [debugger] final class Equatable[A](item: A)
+  extends SometimesEquatable[A](item) {
+  override def equals(obj: Any): Boolean = obj match {
+    case eq: Equatable[A] => eq.item.equals(item)
+    case _                => false
+  }
+
+  override def hashCode(): Int = item.hashCode()
+}
+
+private [debugger] final class Referential[A](item: A)
+  extends SometimesEquatable[A](item)
+
+private [debugger] object SometimesEquatable {
+  def equatable[A](item: A): SometimesEquatable[A] = new Equatable[A](item)
+  def referential[A](item: A): SometimesEquatable[A] = new Referential[A](item)
 }

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/DebugTreeBuilder.scala
@@ -19,7 +19,7 @@ private [parsley] case class DebugTreeBuilder(
           val uuid = uid
           uid = uid + 1
           uuid
-        }}", cs.reconstruct) }
+        }}", cs.reconstruct) }.toList.reverse
       )
 
     node

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/SometimesEquatable.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/SometimesEquatable.scala
@@ -1,0 +1,24 @@
+package parsley.debugger.internal
+
+// Classes that can optionally hide the equals implementation of an item.
+private [debugger] sealed abstract class SometimesEquatable[A](val item: A) {
+  override def toString: String = s"$item [?=]"
+}
+
+private [debugger] final class Equatable[A](item: A)
+  extends SometimesEquatable[A](item) {
+  override def equals(obj: Any): Boolean = obj match {
+    case eq: Equatable[A] => eq.item.equals(item)
+    case _                => false
+  }
+
+  override def hashCode(): Int = item.hashCode()
+}
+
+private [debugger] final class Referential[A](item: A)
+  extends SometimesEquatable[A](item)
+
+private [debugger] object SometimesEquatable {
+  def equatable[A](item: A): SometimesEquatable[A] = new Equatable[A](item)
+  def referential[A](item: A): SometimesEquatable[A] = new Referential[A](item)
+}

--- a/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debugger/DebuggerInstrs.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debugger/DebuggerInstrs.scala
@@ -6,7 +6,7 @@ package parsley.internal.machine.instructions.debugger
 import parsley.debugger.ParseAttempt
 import parsley.debugger.internal.DebugContext
 
-import parsley.internal.deepembedding.frontend.LazyParsley
+import parsley.internal.deepembedding.frontend.{Iterative, LazyParsley}
 import parsley.internal.machine.Context
 import parsley.internal.machine.instructions.{Instr, InstrWithLabel}
 
@@ -19,7 +19,7 @@ private [internal] class EnterParser
   (implicit dbgCtx: DebugContext) extends InstrWithLabel with DebuggerInstr {
   override def apply(ctx: Context): Unit = {
     // I think we can get away with executing this unconditionally.
-    dbgCtx.push(ctx.input, origin)
+    dbgCtx.push(ctx.input, origin, origin.isInstanceOf[Iterative])
     ctx.pushCheck() // Save our location for inputs.
     ctx.pushHandler(label) // Mark the AddAttempt instruction as an exit handler.
     ctx.inc()
@@ -50,7 +50,6 @@ private [internal] class AddAttemptAndLeave(implicit dbgCtx: DebugContext) exten
 
     // Construct a new parse attempt and add it in.
     dbgCtx.addParseAttempt(
-//      ctx.input,
       ParseAttempt(
         input,
         prevCheck,

--- a/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debugger/DebuggerInstrs.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debugger/DebuggerInstrs.scala
@@ -57,7 +57,8 @@ private [internal] class AddAttemptAndLeave(implicit dbgCtx: DebugContext) exten
         if (ctx.good) currentOff else currentOff + 1,
         prevPos,
         if (ctx.good) (ctx.line, ctx.col - 1) else (ctx.line, ctx.col),
-        success
+        success,
+        if (success) Some(ctx.stack.peek) else None
       )
     )
 

--- a/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debugger/DebuggerInstrs.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debugger/DebuggerInstrs.scala
@@ -19,7 +19,7 @@ private [internal] class EnterParser
   (implicit dbgCtx: DebugContext) extends InstrWithLabel with DebuggerInstr {
   override def apply(ctx: Context): Unit = {
     // I think we can get away with executing this unconditionally.
-    dbgCtx.push(origin)
+    dbgCtx.push(ctx.input, origin)
     ctx.pushCheck() // Save our location for inputs.
     ctx.pushHandler(label) // Mark the AddAttempt instruction as an exit handler.
     ctx.inc()
@@ -50,7 +50,7 @@ private [internal] class AddAttemptAndLeave(implicit dbgCtx: DebugContext) exten
 
     // Construct a new parse attempt and add it in.
     dbgCtx.addParseAttempt(
-      ctx.input,
+//      ctx.input,
       ParseAttempt(
         input,
         prevCheck,

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
@@ -6,16 +6,20 @@ package parsley.internal.deepembedding.frontend
 import parsley.internal.deepembedding.ContOps, ContOps.{suspend, ContAdapter}
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 
-private [parsley] final class Many[A](p: LazyParsley[A]) extends Unary[A, List[A]](p) {
+// Marks a parser as being explicitly iterative.
+// It does nothing at all other than that.
+sealed trait Iterative
+
+private [parsley] final class Many[A](p: LazyParsley[A]) extends Unary[A, List[A]](p) with Iterative {
     override def make(p: StrictParsley[A]): StrictParsley[List[A]] = new backend.Many(p)
 }
-private [parsley] final class SkipMany[A](p: LazyParsley[A]) extends Unary[A, Unit](p) {
+private [parsley] final class SkipMany[A](p: LazyParsley[A]) extends Unary[A, Unit](p) with Iterative {
     override def make(p: StrictParsley[A]): StrictParsley[Unit] = new backend.SkipMany(p)
 }
-private [parsley] final class ChainPost[A](p: LazyParsley[A], _op: =>LazyParsley[A => A]) extends Binary[A, A => A, A](p, _op) {
+private [parsley] final class ChainPost[A](p: LazyParsley[A], _op: =>LazyParsley[A => A]) extends Binary[A, A => A, A](p, _op) with Iterative {
     override def make(p: StrictParsley[A], op: StrictParsley[A => A]): StrictParsley[A] = new backend.ChainPost(p, op)
 }
-private [parsley] final class ChainPre[A](p: LazyParsley[A], op: LazyParsley[A => A]) extends LazyParsley[A] {
+private [parsley] final class ChainPre[A](p: LazyParsley[A], op: LazyParsley[A => A]) extends LazyParsley[A] with Iterative {
     def itemParser: LazyParsley[A] = p
 
     def opParser: LazyParsley[A => A] = op
@@ -30,19 +34,19 @@ private [parsley] final class ChainPre[A](p: LazyParsley[A], op: LazyParsley[A =
         } yield new backend.ChainPre(p, op)
 }
 private [parsley] final class Chainl[A, B](init: LazyParsley[B], p: =>LazyParsley[A], op: =>LazyParsley[(B, A) => B])
-    extends Ternary[B, A, (B, A) => B, B](init, p, op) {
+    extends Ternary[B, A, (B, A) => B, B](init, p, op) with Iterative {
     override def make(init: StrictParsley[B], p: StrictParsley[A], op: StrictParsley[(B, A) => B]): StrictParsley[B] = new backend.Chainl(init, p, op)
 }
 private [parsley] final class Chainr[A, B](p: LazyParsley[A], op: =>LazyParsley[(A, B) => B], private [Chainr] val wrap: A => B)
-    extends Binary[A, (A, B) => B, B](p, op)  {
+    extends Binary[A, (A, B) => B, B](p, op) with Iterative {
     override def make(p: StrictParsley[A], op: StrictParsley[(A, B) => B]): StrictParsley[B] = new backend.Chainr(p, op, wrap)
 }
-private [parsley] final class SepEndBy1[A, B](p: LazyParsley[A], sep: =>LazyParsley[B]) extends Binary[A, B, List[A]](p, sep) {
+private [parsley] final class SepEndBy1[A, B](p: LazyParsley[A], sep: =>LazyParsley[B]) extends Binary[A, B, List[A]](p, sep) with Iterative {
     override def make(p: StrictParsley[A], sep: StrictParsley[B]): StrictParsley[List[A]] = new backend.SepEndBy1(p, sep)
 }
-private [parsley] final class ManyUntil[A](body: LazyParsley[Any]) extends Unary[Any, List[A]](body) {
+private [parsley] final class ManyUntil[A](body: LazyParsley[Any]) extends Unary[Any, List[A]](body) with Iterative {
     override def make(p: StrictParsley[Any]): StrictParsley[List[A]] = new backend.ManyUntil(p)
 }
-private [parsley] final class SkipManyUntil(body: LazyParsley[Any]) extends Unary[Any, Unit](body) {
+private [parsley] final class SkipManyUntil(body: LazyParsley[Any]) extends Unary[Any, Unit](body) with Iterative {
     override def make(p: StrictParsley[Any]): StrictParsley[Unit] = new backend.SkipManyUntil(p)
 }


### PR DESCRIPTION
This is to eliminate the memory usage of the path list and the amount of dependency on copying immutable ListMaps.