### PR TITLE
Use Java reflection for Scala 3 on the JVM

### DIFF
--- a/parsley-debug/jvm/src/main/scala-2/parsley/debugger/util/XCollector.scala
+++ b/parsley-debug/jvm/src/main/scala-2/parsley/debugger/util/XCollector.scala
@@ -64,12 +64,7 @@ private [parsley] object XCollector extends CollectorImpl {
 
         // Use reflection to collect hidden parsers from a lexer, as they're set to be inaccessible from the outside.
         val mirror = scala.reflect.runtime.currentMirror
-        val reflPairs = List(
-            lexer.lexeme.text,
-            lexer.lexeme.numeric,
-            lexer.nonlexeme.text,
-            lexer.nonlexeme.numeric
-        ).map(obj => (mirror.classSymbol(obj.getClass), mirror.reflect(obj)))
+        val reflPairs = unsafeLexerObjects(lexer).map(obj => (mirror.classSymbol(obj.getClass), mirror.reflect(obj)))
 
         for ((clazz, lexRefl) <- reflPairs) {
             val getters = clazz.toType.members.collect {

--- a/parsley-debug/jvm/src/main/scala-3/parsley/debugger/util/XCollector.scala
+++ b/parsley-debug/jvm/src/main/scala-3/parsley/debugger/util/XCollector.scala
@@ -8,4 +8,4 @@ package parsley.debugger.util
 // Sadly, no reflective capabilities exist in Scala 3 yet, so these
 // methods don't do anything yet.
 // TODO: Find a substitute for reflection for Scala 3.
-private [parsley] object XCollector extends XDummyCollector
+private [parsley] object XCollector extends XCollectorJava

--- a/parsley-debug/jvm/src/main/scala/parsley/debugger/util/XCollectorJava.scala
+++ b/parsley-debug/jvm/src/main/scala/parsley/debugger/util/XCollectorJava.scala
@@ -1,0 +1,55 @@
+package parsley.debugger.util
+
+import scala.annotation.nowarn
+import scala.collection.mutable
+import scala.util.{Success, Try}
+
+import parsley.debugger.internal.Rename.MapAddAll
+import parsley.token.Lexer
+
+import parsley.internal.deepembedding.frontend.LazyParsley
+
+// Java-reflection powered XCollector. For backup purposes. Not meant to be used directly, but inherited from.
+// The setAccessible methods on private members is a deprecated action, so proceed with caution.
+// $COVERAGE-OFF$
+private [parsley] abstract class XCollectorJava extends CollectorImpl {
+    override val supported: Boolean = true
+
+    private def getParsers(obj: Any): Try[Map[LazyParsley[_], String]] = {
+        val accumulator: mutable.HashMap[LazyParsley[_], String] = new mutable.HashMap()
+
+        Try {
+            // FIXME: Type matching by name is very brittle...
+            val parserGetters = obj.getClass.getDeclaredMethods.filter { mth =>
+                Seq(Class.forName("parsley.Parsley"), Class.forName("parsley.internal.deepembedding.frontend.LazyParsley"))
+                    .contains(mth.getReturnType) && mth.getParameterCount == 0
+            }
+
+            parserGetters.foreach(_.setAccessible(true)) // FIXME: This is deprecated API and may be removed in a later Java version!
+            parserGetters.foreach { mth => accumulator(tryExtract(mth.invoke(obj))) = mth.getName }
+
+            accumulator.toMap
+        }.orElse(Success(accumulator.toMap))
+    }
+
+    @nowarn override def collectNames(obj: Any): Map[LazyParsley[_], String] = getParsers(obj).getOrElse(Map.empty)
+
+    @nowarn override def collectLexer(lexer: Lexer): Map[LazyParsley[_], String] = {
+        val accumulator: mutable.HashMap[LazyParsley[_], String] = new mutable.HashMap()
+
+        Try {
+            // Safe lexer objects need only one reflection step.
+            safeLexerObjects(lexer).foreach(obj => accumulator.addAllFrom(collectNames(obj)))
+
+            // For these "unsafe" objects, we need to reflect them twice.
+            unsafeLexerObjects(lexer).foreach { uob =>
+                val getters = uob.getClass.getDeclaredMethods.filter(_.getParameterCount == 0)
+                getters.foreach(_.setAccessible(true))
+                getters.foreach(get => accumulator.addAllFrom(collectNames(get.invoke(uob))))
+            }
+
+            accumulator.toMap
+        }.orElse(Success(accumulator.toMap))
+    }.getOrElse(Map.empty)
+}
+// $COVERAGE-ON$

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/Rename.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/Rename.scala
@@ -52,7 +52,7 @@ private [parsley] object Rename {
         }
 
         // This renames the parser if it is present, otherwise gives the default name found earlier.
-        optName.getOrElse(collected.getOrElse(extracted, defaultName))
+        translate(optName.getOrElse(collected.getOrElse(extracted, defaultName)))
     }
 
     // Perform the first step of renaming, a partial rename where only the type name is exposed.
@@ -69,5 +69,39 @@ private [parsley] object Rename {
 
     private [parsley] def addName(par: LazyParsley[_], name: String): Unit = {
         val _ = collected.put(par, name): @unused
+    }
+
+    // Translation table for Scala operator names.
+    private[this] lazy val operatorTable: Map[String, Char] = Map(
+        ("times", '*'),
+        ("percent", '%'),
+        ("div", '/'),
+        ("plus", '+'),
+        ("minus", '-'),
+        ("colon", ':'),
+        ("less", '<'),
+        ("greater", '>'),
+        ("eq", '='),
+        ("bang", '!'),
+        ("amp", '&'),
+        ("up", '^'),
+        ("bar", '|'),
+        ("tilde", '~')
+    )
+
+    // Translate a fully-qualified class name into something more human-readable.
+    private[this] def translate(name: String): String = {
+        val lastDot = name.lastIndexOf(".")
+        val uName =
+            if (lastDot == -1) name
+            else name.drop(lastDot + 1)
+
+        if (uName.contains('$')) {
+            uName.split('$')
+              .map((seg: String) => operatorTable.get(seg).map(c => s"$c").getOrElse(seg))
+              .mkString
+        } else {
+            uName
+        }
     }
 }

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/internal/Rename.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/internal/Rename.scala
@@ -52,7 +52,7 @@ private [parsley] object Rename {
         }
 
         // This renames the parser if it is present, otherwise gives the default name found earlier.
-        translate(optName.getOrElse(collected.getOrElse(extracted, defaultName)))
+        optName.getOrElse(collected.getOrElse(extracted, defaultName))
     }
 
     // Perform the first step of renaming, a partial rename where only the type name is exposed.
@@ -69,39 +69,5 @@ private [parsley] object Rename {
 
     private [parsley] def addName(par: LazyParsley[_], name: String): Unit = {
         val _ = collected.put(par, name): @unused
-    }
-
-    // Translation table for Scala operator names.
-    private[this] lazy val operatorTable: Map[String, Char] = Map(
-        ("times", '*'),
-        ("percent", '%'),
-        ("div", '/'),
-        ("plus", '+'),
-        ("minus", '-'),
-        ("colon", ':'),
-        ("less", '<'),
-        ("greater", '>'),
-        ("eq", '='),
-        ("bang", '!'),
-        ("amp", '&'),
-        ("up", '^'),
-        ("bar", '|'),
-        ("tilde", '~')
-    )
-
-    // Translate a fully-qualified class name into something more human-readable.
-    private[this] def translate(name: String): String = {
-        val lastDot = name.lastIndexOf(".")
-        val uName =
-            if (lastDot == -1) name
-            else name.drop(lastDot + 1)
-
-        if (uName.contains('$')) {
-            uName.split('$')
-              .map((seg: String) => operatorTable.get(seg).map(c => s"$c").getOrElse(seg))
-              .mkString
-        } else {
-            uName
-        }
     }
 }

--- a/parsley-debug/shared/src/main/scala/parsley/debugger/util/Collector.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debugger/util/Collector.scala
@@ -102,7 +102,7 @@ private [parsley] abstract class CollectorImpl {
     // All of these objects inside a lexer are exposed, so are easy to collect parser names from.
     // The rest will need to be handled by reflection.
     // If any public objects are added to Lexer, please add them to this list.
-    @inline protected def safeLexerObjects(lexer: Lexer): List[Any] = List(
+    @inline protected final def safeLexerObjects(lexer: Lexer): List[Any] = List(
         lexer,
         lexer.space,
         lexer.lexeme,
@@ -117,6 +117,15 @@ private [parsley] abstract class CollectorImpl {
         lexer.nonlexeme.numeric,
         lexer.nonlexeme.symbol,
         lexer.nonlexeme.text
+    )
+
+    // All of these objects inside a lexer have private parsers, so will require some fine-grained combing to find all
+    // of their internal parsers and their names.
+    @inline protected final def unsafeLexerObjects(lexer: Lexer): List[Any] = List(
+        lexer.lexeme.text,
+        lexer.lexeme.numeric,
+        lexer.nonlexeme.text,
+        lexer.nonlexeme.numeric
     )
 }
 // $COVERAGE-ON$

--- a/parsley/shared/src/main/scala/parsley/token/Lexer.scala
+++ b/parsley/shared/src/main/scala/parsley/token/Lexer.scala
@@ -236,9 +236,12 @@ class Lexer(desc: descriptions.LexicalDesc, errConfig: errors.ErrorConfig) {
       */
     def this(desc: descriptions.LexicalDesc) = this(desc, new errors.ErrorConfig)
 
-    // Note: If any public objects are added into this class that contain any Parsley[_] parsers,
+    // Note: If any members with only public parsers are added into this class,
     //       please also add those objects into the safeLexerObjects list within CollectorImpl
-    //       (found in Collector.scala in parsley-debug/src/shared).
+    //       (found in Collector.scala in parsley-debug/src/shared). If those members are terms that
+    //       contain other parsers, add them to that list too.
+    //       Members with private members (in which those private members contain parsers) must be
+    //       added to unsafeLexerObjects (where they will be reflected twice).
 
     private val generic = new numeric.Generic(errConfig)
 


### PR DESCRIPTION
This is not what you'd call "safe", per-se, but it is a stop-gap measure until a safer replacement for it (equivalent to `scala-reflect`) exists for Scala 3.